### PR TITLE
Fix loading prop receiving a non-boolean value

### DIFF
--- a/.changeset/chilly-jars-teach.md
+++ b/.changeset/chilly-jars-teach.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-react': patch
+---
+
+Fix warning about the loading receiving a non-boolean attribute

--- a/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
+++ b/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
@@ -147,7 +147,12 @@ function EmailAuth({
           </div>
         </Container>
 
-        <Button type="submit" color="primary" appearance={appearance}>
+        <Button
+          type="submit"
+          color="primary"
+          loading={loading}
+          appearance={appearance}
+        >
           {i18n?.[authView]?.button_label}
         </Button>
 

--- a/packages/react/src/components/UI/Button.tsx
+++ b/packages/react/src/components/UI/Button.tsx
@@ -54,6 +54,8 @@ const Button: React.FC<ButtonProps> = ({
   children,
   color = 'default',
   appearance,
+  icon,
+  loading = false,
   ...props
 }) => {
   const classNames = generateClassNames(
@@ -67,8 +69,9 @@ const Button: React.FC<ButtonProps> = ({
       {...props}
       style={appearance?.style?.button}
       className={classNames.join(' ')}
+      disabled={loading}
     >
-      {props.icon}
+      {icon}
       {children}
     </button>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Showing a warning `Received false for a non-boolean attribute loading.`

## What is the new behavior?

No longer shows the warning

## Additional context

Add any other context or screenshots.
