### PR TITLE
WIP: give a initial email adress to the auth screen

### DIFF
--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -20,6 +20,7 @@ function Auth({
   providerScopes,
   queryParams,
   view = 'sign_in',
+  initialEmail,
   redirectTo,
   onlyThirdPartyProviders = false,
   magicLink = false,
@@ -38,7 +39,7 @@ function Auth({
   const i18n: I18nVariables = merge(en, localization.variables ?? {})
 
   const [authView, setAuthView] = useState(view)
-  const [defaultEmail, setDefaultEmail] = useState('')
+  const [defaultEmail, setDefaultEmail] = useState(initialEmail)
   const [defaultPassword, setDefaultPassword] = useState('')
 
   /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

This allows developers to give the ui an initial email address. See https://github.com/orgs/supabase/discussions/20632

# TODO:

- [ ] svelte implementation
- [ ] solidjs implementation
- [ ] add documentation

