### PR TITLE
feat: bump supabase js version to v2.39.3

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,10 +38,10 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@supabase/supabase-js": "^2.21.0"
+    "@supabase/supabase-js": "^2.39.3"
   },
   "devDependencies": {
-    "@supabase/supabase-js": "^2.21.0",
+    "@supabase/supabase-js": "^2.39.3",
     "@types/is-ci": "^3.0.0",
     "@types/minimist": "^1.2.2",
     "@types/node": "^18.14.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,11 +32,11 @@
   "homepage": "https://github.com/supabase/auth-ui#readme",
   "devDependencies": {
     "@stitches/core": "^1.2.8",
-    "@supabase/supabase-js": "^2.21.0",
+    "@supabase/supabase-js": "^2.39.3",
     "tsconfig": "workspace:*",
     "tsup": "^6.6.3"
   },
   "peerDependencies": {
-    "@supabase/supabase-js": "^2.21.0"
+    "@supabase/supabase-js": "^2.39.3"
   }
 }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@suid/icons-material": "^0.4.1",
     "@suid/material": "^0.6.3",
-    "@supabase/supabase-js": "^2.21.0",
+    "@supabase/supabase-js": "^2.39.3",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "eslint": "^8.33.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.25.0",
-		"@supabase/supabase-js": "^2.21.0",
+		"@supabase/supabase-js": "^2.39.3",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/kit": "^1.15.2",
 		"@sveltejs/package": "^2.0.2",
@@ -58,6 +58,6 @@
 		"vite": "^4.5.2"
 	},
 	"peerDependencies": {
-		"@supabase/supabase-js": "^2.21.0"
+		"@supabase/supabase-js": "^2.39.3"
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgrade supabase js version to v2.39.3. This includes a fix on the [`PASSWORD_RECOVERY` event](https://github.com/supabase/gotrue-js/pull/829) which might help with some of the issues



