### PR TITLE
Added onViewChanged to React Auth UI so that view can be externally synchronized

### DIFF
--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -30,6 +30,7 @@ function Auth({
   otpType = 'email',
   additionalData,
   passwordLimit,
+  onViewChange,
   children,
 }: AuthProps): JSX.Element | null {
   /**
@@ -41,6 +42,12 @@ function Auth({
   const [authView, setAuthView] = useState(view)
   const [defaultEmail, setDefaultEmail] = useState('')
   const [defaultPassword, setDefaultPassword] = useState('')
+
+  useEffect(() => {
+    if (onViewChange) {
+      onViewChange(authView)
+    }
+  }, [authView, onViewChange])
 
   /**
    * Simple boolean to detect if authView 'sign_in' or 'sign_up' or 'magic_link' is used

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,4 @@
-import { BaseAppearance, BaseAuth } from '@supabase/auth-ui-shared'
+import { BaseAppearance, BaseAuth, ViewType } from '@supabase/auth-ui-shared'
 import { CSSProperties, ReactNode } from 'react'
 
 export interface Appearance extends BaseAppearance {
@@ -17,4 +17,5 @@ export interface Appearance extends BaseAppearance {
 export interface Auth extends BaseAuth {
   children?: ReactNode
   appearance?: Appearance
+  onViewChange?: (view: ViewType) => void
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This introduces a feature where you can pass a callback `onViewChanged` to the `Auth` component for React. This callback gets executed, whenever the view of the Auth UI changes so that you can externally synchronize with it.

My specific use-case of it was that I wanted to synchronize the `redirectUrl` with whatever view a user selected. For example on sign up I want to redirect to `[main app URL]/onboarding` while on the forgotten password page I want to redirect to `[main app URL]/reset-password`.

This could also potentially help with #236 

Also remember that the `redirectUrl` needs to match the redirect URL settings on Supabase.

## What is the current behavior?

When a view is selected, that state is isolated to the Auth UI component. You can pass the initial view, but cannot listen to changes.

## What is the new behavior?

See feature description above; `onViewChanged` gets called by Auth UI component whenever the view changes.

## Additional context

Example of how I use this new feature:

```ts
  const [view, setView] = useState<ViewType>("sign_in");
  const [redirectTo, setRedirectTo] = useState<string | undefined>();

  useEffect(() => {
    const currentUrl = new URL(window.location.href);
    switch (view) {
      case "sign_in":
      case "sign_up":
        setRedirectTo(currentUrl.origin + "/onboarding");
        break;
      case "forgotten_password":
        setRedirectTo(currentUrl.origin + "/reset-password");
        break;
      default:
        setRedirectTo(undefined);
        break;
    }
  }, [view]);
```

```tsx
          <Auth
            supabaseClient={supabase}
            view={view}
            onViewChange={(view) => {
              setView(view);
            }}
            redirectTo={redirectTo}
          />
```
