### PR TITLE
Add the ability to enable the shouldCreateUser on passwordless login

### DIFF
--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -42,7 +42,9 @@ function App() {
   const [brandColor, setBrandColor] = useState(colors[0] as string)
   const [borderRadius, setBorderRadius] = useState(radii[0] as string)
   const [theme, setTheme] = useState('dark')
-  const [socialLayout, setSocialLayout] = useState<SocialLayout>(socialAlignments[1] satisfies SocialLayout)
+  const [socialLayout, setSocialLayout] = useState<SocialLayout>(
+    socialAlignments[1] satisfies SocialLayout
+  )
   const [view, setView] = useState(views[0])
 
   return (
@@ -64,6 +66,7 @@ function App() {
                 </div>
                 <Auth
                   supabaseClient={supabase}
+                  additionalData={{ shouldCreateUser: false }}
                   view={view.id}
                   appearance={{
                     theme: ThemeSupa,
@@ -210,14 +213,18 @@ function App() {
                   <div className="relative inline-flex self-center">
                     <select
                       defaultValue={view.id}
-                      onChange={(e) => { 
-                        const vw = views.filter(v => v.id === e.target.value).pop() ?? view
+                      onChange={(e) => {
+                        const vw =
+                          views.filter((v) => v.id === e.target.value).pop() ??
+                          view
                         setView(vw)
                       }}
                       className="text-lg rounded border-2 border-blue-700 text-gray-600 pl-5 pr-10 h-12 bg-white hover:border-gray-400 appearance-none"
                     >
                       {views.map((v) => (
-                        <option key={v.id} value={v.id}>{v.title}</option>
+                        <option key={v.id} value={v.id}>
+                          {v.title}
+                        </option>
                       ))}
                     </select>
                   </div>

--- a/examples/react/src/app.css
+++ b/examples/react/src/app.css
@@ -1,5 +1,5 @@
 /*
-! tailwindcss v3.2.7 | MIT License | https://tailwindcss.com
+! tailwindcss v3.3.3 | MIT License | https://tailwindcss.com
 */
 
 /*
@@ -31,6 +31,7 @@
 3. Use a more readable tab size.
 4. Use the user's configured `sans` font-family by default.
 5. Use the user's configured `sans` font-feature-settings by default.
+6. Use the user's configured `sans` font-variation-settings by default.
 */
 
 html {
@@ -47,6 +48,8 @@ html {
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
+  font-variation-settings: normal;
+  /* 6 */
 }
 
 /*
@@ -187,6 +190,10 @@ optgroup,
 select,
 textarea {
   font-family: inherit;
+  /* 1 */
+  font-feature-settings: inherit;
+  /* 1 */
+  font-variation-settings: inherit;
   /* 1 */
   font-size: 100%;
   /* 1 */
@@ -339,6 +346,14 @@ menu {
 }
 
 /*
+Reset default styling for dialogs.
+*/
+
+dialog {
+  padding: 0;
+}
+
+/*
 Prevent resizing textareas horizontally by default.
 */
 
@@ -433,6 +448,9 @@ video {
   --tw-pan-y:  ;
   --tw-pinch-zoom:  ;
   --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
   --tw-ordinal:  ;
   --tw-slashed-zero:  ;
   --tw-numeric-figure:  ;
@@ -480,6 +498,9 @@ video {
   --tw-pan-y:  ;
   --tw-pinch-zoom:  ;
   --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
   --tw-ordinal:  ;
   --tw-slashed-zero:  ;
   --tw-numeric-figure:  ;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "npm": ">=9.0.0",
     "node": ">=18.0.0"
   },
-  "packageManager": "pnpm@8.7.0",
+  "packageManager": "pnpm@9.1.0",
   "peerDependencies": {
     "typescript": "4.4.x || 4.5.x || 4.6.x"
   }

--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -192,6 +192,7 @@ function Auth({
             setAuthView={setAuthView}
             redirectTo={redirectTo}
             showLinks={showLinks}
+            additionalData={additionalData}
             i18n={i18n}
           />
         </Container>


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Update the requirements to use the latest pnpm.
- Ability to pass "additionalData" to the `<MagicLink>`.
- Implement the logic for `<MagicLink>` when "additionalData" is provided (as it's optional).

## What is the current behavior?
You're not able to provide any additional data, therefore you can't decide if you want to create users when a customer uses OTP.

## What is the new behavior?
Passing the proper option, you'll be able to decide if you want to have shouldCreateUser
```typescript
 <Auth
    supabaseClient={supabase}
    additionalData={{ shouldCreateUser: false }}
    view={view.id}
```
Furthermore, we're using the SignInWithPasswordlessCredentials and we are adding the ability to pass data too

```typescript
const signInOptions: SignInWithPasswordlessCredentials = {
      email,
      options: {
        emailRedirectTo: redirectTo,
        data: restData,
        ...(shouldCreateUser !== undefined && { shouldCreateUser }),
```

## Additional context

I've decided to re-use the additionalData, as it's used on another component, and it seems to continue with the logic of the original author. 


